### PR TITLE
Hide horizontal scroll bar below Leaflet map

### DIFF
--- a/packages/geojson-extension/style/index.css
+++ b/packages/geojson-extension/style/index.css
@@ -9,11 +9,11 @@
 }
 
 /* Base styles */
-.jp-RenderedGeoJSON {
+.jp-RenderedGeoJSON.leaflet-container {
   width: 100%;
   height: 100%;
   padding: 0;
-  overflow: hidden !important;
+  overflow: hidden;
 }
 
 /* Document styles */

--- a/packages/geojson-extension/style/index.css
+++ b/packages/geojson-extension/style/index.css
@@ -13,7 +13,7 @@
   width: 100%;
   height: 100%;
   padding: 0;
-  overflow: hidden;
+  overflow: hidden !important;
 }
 
 /* Document styles */


### PR DESCRIPTION
The `overflow: hidden;` directive was overridden by `.jp-OutputArea-output`'s `overflow-x: auto;`, resulting in an ugly horizontal scrollbar below the leaflet map that jumped around all the time when panning, as Leaflet loaded new tiles.