### PR TITLE
Fix invalidate size in geojson outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
 - jupyter labextension link packages/vdom-extension --no-build
 - jupyter labextension link packages/katex-extension --no-build
 - jupyter lab build 
-- python -m jupyterlab.selenium_check
+- python -m jupyterlab.selenium_check --NotebookApp.ip=127.0.0.1

--- a/packages/geojson-extension/package.json
+++ b/packages/geojson-extension/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^0.4.0",
+    "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.3.0",
     "leaflet": "^1.2.0"
   },

--- a/packages/geojson-extension/src/index.tsx
+++ b/packages/geojson-extension/src/index.tsx
@@ -98,7 +98,7 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
       // Update map size after panel/window is resized
       this._map.fitBounds(this._geoJSONLayer.getBounds());
       this.update();
-      resolve(undefined);
+      resolve();
     });
   }
   

--- a/packages/plotly-extension/package.json
+++ b/packages/plotly-extension/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^0.4.0",
+    "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.3.0",
     "plotly.js": "^1.28.3"
   },

--- a/packages/plotly-extension/src/index.tsx
+++ b/packages/plotly-extension/src/index.tsx
@@ -6,6 +6,10 @@ import {
 } from '@phosphor/widgets';
 
 import {
+  Message
+} from '@phosphor/messaging';
+
+import {
   IRenderMime
 } from '@jupyterlab/rendermime-interfaces';
 
@@ -76,36 +80,38 @@ class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
   renderModel(model: IRenderMime.IMimeModel): Promise<void> {
     const { data, layout } = model.data[this._mimeType] as any|PlotlySpec;
     // const metadata = model.metadata[this._mimeType] as any || {};
-    return Plotly.newPlot(this.node, data, layout)
-      .then(() => Plotly.Plots.resize(this.node))
-      // .then(plot =>
-      //   Plotly.toImage(plot, {
-      //     format: 'png',
-      //     width: this._width,
-      //     height: this._height
-      //   }))
-      // .then(() => {
-      //   const data = url.split(',')[1];
+    return Plotly.newPlot(this.node, data, layout).then((plot) => {
+      this.update();
+      // return Plotly.toImage(plot, {
+      //   format: 'png',
+      //   width: this.node.offsetWidth,
+      //   height: this.node.offsetHeight
+      // }).then(url => {
+      //   const imageData = url.split(',')[1];
+      //   model.setData({ data: { ...data, 'image/png': imageData } });
       // });
+    });
   }
-
+  
+  /**
+   * A message handler invoked on an `'after-show'` message.
+   */
+  protected onAfterShow(msg: Message): void {
+    this.update();
+  }
+    
   /**
    * A message handler invoked on a `'resize'` message.
    */
-  protected onResize(msg: Widget.ResizeMessage) {
-    Plotly.redraw(this.node)
-      .then(() => {
-        Plotly.Plots.resize(this.node);
-      });
-      // .then(plot =>
-      //   Plotly.toImage(plot, {
-      //     format: 'png',
-      //     width: this._width,
-      //     height: this._height
-      //   }))
-      // .then(url => {
-      //   const data = url.split(',')[1];
-      // });
+  protected onResize(msg: Widget.ResizeMessage): void {
+    this.update();
+  }
+  
+  /**
+   * A message handler invoked on an `'update-request'` message.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    if (this.isVisible) Plotly.redraw(this.node);
   }
 
   private _mimeType: string;


### PR DESCRIPTION
Without a `setTimeout` (of any timeout value), I’m observing that geojson outputs don’t invalidate size and as a result render only a portion of their tiles. Documents don’t have this issue. I don’t really understand why so this is a temporary fix until we understand what’s going on.

As a side note: The scroll wheel zoom logic is only necessary for outputs (vs. documents), but I don’t know how to detect whether the widget is being used within an output or document context. 