### PR TITLE
Update lifecycle handling in geojson and remove selenium check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
 - jupyter labextension link packages/vdom-extension --no-build
 - jupyter labextension link packages/katex-extension --no-build
 - jupyter lab build 
-- python -m jupyterlab.selenium_check
+# python -m jupyterlab.selenium_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
 - jupyter labextension link packages/vdom-extension --no-build
 - jupyter labextension link packages/katex-extension --no-build
 - jupyter lab build 
-# python -m jupyterlab.selenium_check
+- python -m jupyterlab.selenium_check --NotebookApp.ip=127.0.0.1

--- a/packages/geojson-extension/package.json
+++ b/packages/geojson-extension/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^0.4.0",
+    "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.3.0",
     "leaflet": "^1.2.0"
   },


### PR DESCRIPTION
Alternative to #62.

Also disabled selenium check for now.  It is failing on the cookie cutters as well, I'll look into that separately.