### PR TITLE
Add standardized keyword for extension

### DIFF
--- a/packages/fasta-extension/package.json
+++ b/packages/fasta-extension/package.json
@@ -6,7 +6,8 @@
   "types": "lib/index.d.ts",
   "keywords": [
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab-extension"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/geojson-extension/package.json
+++ b/packages/geojson-extension/package.json
@@ -12,6 +12,11 @@
   "directories": {
     "lib": "lib/"
   },
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
   "jupyterlab": {
     "mimeExtension": true
   },

--- a/packages/katex-extension/package.json
+++ b/packages/katex-extension/package.json
@@ -15,6 +15,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
+    "jupyterlab-extension",
     "katex"
   ],
   "dependencies": {

--- a/packages/plotly-extension/package.json
+++ b/packages/plotly-extension/package.json
@@ -12,6 +12,11 @@
   "directories": {
     "lib": "lib/"
   },
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
   "jupyterlab": {
     "mimeExtension": true
   },

--- a/packages/vega3-extension/package.json
+++ b/packages/vega3-extension/package.json
@@ -12,6 +12,11 @@
   "directories": {
     "lib": "lib/"
   },
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
   "jupyterlab": {
     "mimeExtension": true
   },


### PR DESCRIPTION
Eases discoverability of extensions on npm registry.

C.f. https://github.com/jupyterlab/jupyterlab/issues/3841.