### PR TITLE
Fix polygon map bounds

### DIFF
--- a/packages/geojson-extension/src/index.tsx
+++ b/packages/geojson-extension/src/index.tsx
@@ -123,6 +123,7 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
     });
   }
   
+
   /**
    * A message handler invoked on an `'after-attach'` message.
    */
@@ -139,13 +140,19 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
         this._map.scrollWheelZoom.enable();
       });
     }
+    // Update map size after panel/window is resized
+    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
+
+
   
   /**
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
+    // Update map size after panel/window is resized
+    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
     
@@ -153,6 +160,8 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
    * A message handler invoked on a `'resize'` message.
    */
   protected onResize(msg: Widget.ResizeMessage): void {
+    // Update map size after panel/window is resized
+    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
   
@@ -162,6 +171,8 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
   protected onUpdateRequest(msg: Message): void {
     // Update map size after update
     if (this.isVisible) this._map.invalidateSize();
+    // Update map size after panel/window is resized
+    this._map.fitBounds(this._geoJSONLayer.getBounds());
   }
 
   private _map: leaflet.Map;

--- a/packages/geojson-extension/src/index.tsx
+++ b/packages/geojson-extension/src/index.tsx
@@ -116,8 +116,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
       ).addTo(this._map);
       // Create GeoJSON layer from data and add to map
       this._geoJSONLayer = leaflet.geoJSON(data).addTo(this._map);
-      // Update map size after panel/window is resized
-      this._map.fitBounds(this._geoJSONLayer.getBounds());
       this.update();
       resolve();
     });
@@ -140,8 +138,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
         this._map.scrollWheelZoom.enable();
       });
     }
-    // Update map size after panel/window is resized
-    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
 
@@ -151,8 +147,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    // Update map size after panel/window is resized
-    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
     
@@ -160,8 +154,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
    * A message handler invoked on a `'resize'` message.
    */
   protected onResize(msg: Widget.ResizeMessage): void {
-    // Update map size after panel/window is resized
-    this._map.fitBounds(this._geoJSONLayer.getBounds());
     this.update();
   }
   

--- a/packages/geojson-extension/src/index.tsx
+++ b/packages/geojson-extension/src/index.tsx
@@ -121,7 +121,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
     });
   }
   
-
   /**
    * A message handler invoked on an `'after-attach'` message.
    */
@@ -140,8 +139,6 @@ class RenderedGeoJSON extends Widget implements IRenderMime.IRenderer {
     }
     this.update();
   }
-
-
   
   /**
    * A message handler invoked on an `'after-show'` message.


### PR DESCRIPTION
Leaflet needs to know the size of the viewport in order to calculate the zoom level for displaying geojson content.
In order to resize gracefully, `fitBounds` needs to be called each time the size of the map is changed.

By moving the `fitBounds` call into `update` we can ensure that the geojson will always fit inside the viewport of the map.
Fixes #28 