### PR TITLE
This version of KaTeX has the most reliable fraction lines for the moment.

### DIFF
--- a/packages/katex-extension/package.json
+++ b/packages/katex-extension/package.json
@@ -22,7 +22,7 @@
     "@jupyterlab/application": "^0.15.1",
     "@jupyterlab/rendermime": "^0.15.1",
     "@jupyterlab/rendermime-interfaces": "^1.0.3",
-    "katex": "^0.9.0"
+    "katex": "^0.9.0-alpha1"
   },
   "devDependencies": {
     "@types/katex": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,7 +3182,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-katex@^0.9.0:
+katex@^0.9.0-alpha1:
   version "0.9.0"
   resolved "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz#26a7d082c21d53725422d2d71da9b2d8455fbd4a"
   dependencies:


### PR DESCRIPTION
Fixes #117. @gnestor, can you see if you can reproduce any of the disappearing fraction lines with this branch?