### PR TITLE
Specify height for KaTeX svg elements.

### DIFF
--- a/packages/katex-extension/style/index.css
+++ b/packages/katex-extension/style/index.css
@@ -4,3 +4,13 @@
 |----------------------------------------------------------------------------*/
 
 @import url('~katex/dist/katex.css');
+
+/**
+ * Note: the KaTeX CSS doesn't apply a height property
+ * to its SVG objects, so it can be overridden by low-
+ * specificity rules elsewhere on the page. This
+ * is a workaround for that behavior.
+ */
+.katex svg {
+  height: inherit;
+}


### PR DESCRIPTION
Another possible fix for #117. How about this @gnestor?