### PR TITLE
Left align math in cell outputs for KaTeX and MathJax3 extensions.

### DIFF
--- a/packages/katex-extension/style/index.css
+++ b/packages/katex-extension/style/index.css
@@ -14,3 +14,8 @@
 .katex svg {
   height: inherit;
 }
+
+.jp-OutputArea-output.jp-RenderedLatex .katex-display {
+  text-align: left;
+  margin: 0;
+}

--- a/packages/mathjax3-extension/style/index.css
+++ b/packages/mathjax3-extension/style/index.css
@@ -4,3 +4,8 @@
 |----------------------------------------------------------------------------*/
 
 @import './fonts.css';
+
+.jp-OutputArea-output.jp-RenderedLatex .MJX-DISPLAY {
+  margin: 0;
+  text-align: left;
+}


### PR DESCRIPTION
Follow-up to jupyterlab/jupyterlab#5115