### PR TITLE
Clean up travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
 language: python
 sudo: false
 dist: trusty
-addons:
-  firefox: latest
 cache: yarn
-before_install:
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
-- mkdir geckodriver
-- tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
-- export PATH=$PATH:$PWD/geckodriver
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start || true
 install:
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 - bash miniconda.sh -b -p $HOME/miniconda
@@ -20,7 +11,6 @@ install:
 - conda update -q conda
 - conda info -a
 - conda install nodejs notebook
-- pip install selenium
 - pip install --pre jupyterlab
 script:
 - yarn


### PR DESCRIPTION
We no longer need Firefox and selenium, since the browser check uses `puppeteer`.