### PR TITLE
Fix JSON error when saving notebook with plotly figure

### DIFF
--- a/packages/plotly-extension/src/index.ts
+++ b/packages/plotly-extension/src/index.ts
@@ -56,31 +56,40 @@ export class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
         return Plotly.addFrames(this.node, frames).then(() => {
           Plotly.animate(this.node);
           this.update();
-          return Plotly.toImage(plot, {
-            format: 'png',
-            width: this.node.offsetWidth,
-            height: this.node.offsetHeight
-          }).then((url: string) => {
-            const imageData = url.split(',')[1];
-            if (model.data['image/png'] !== imageData) {
-              model.setData({
-                data: { ...model.data, 'image/png': imageData }
-              });
-            }
-          });
+          if (this.node.offsetWidth > 0 && this.node.offsetHeight > 0) {
+            return Plotly.toImage(plot, {
+              format: 'png',
+              width: this.node.offsetWidth,
+              height: this.node.offsetHeight
+            }).then((url: string) => {
+              const imageData = url.split(',')[1];
+              if (model.data['image/png'] !== imageData) {
+                model.setData({
+                  data: { ...model.data, 'image/png': imageData }
+                });
+              }
+            });
+          }
         });
       }
       this.update();
-      return Plotly.toImage(plot, {
-        format: 'png',
-        width: this.node.offsetWidth,
-        height: this.node.offsetHeight
-      }).then((url: string) => {
-        const imageData = url.split(',')[1];
-        if (model.data['image/png'] !== imageData) {
-          model.setData({ data: { ...model.data, 'image/png': imageData } });
-        }
-      });
+      if (this.node.offsetWidth > 0 && this.node.offsetHeight > 0) {
+        return Plotly.toImage(plot, {
+          format: 'png',
+          width: this.node.offsetWidth,
+          height: this.node.offsetHeight
+        }).then((url: string) => {
+          const imageData = url.split(',')[1];
+          if (model.data['image/png'] !== imageData) {
+            model.setData({
+              data: {
+                ...model.data,
+                'image/png': imageData
+              }
+            });
+          }
+        });
+      }
     });
   }
 

--- a/packages/plotly-extension/src/index.ts
+++ b/packages/plotly-extension/src/index.ts
@@ -62,7 +62,11 @@ export class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
             height: this.node.offsetHeight
           }).then((url: string) => {
             const imageData = url.split(',')[1];
-            model.setData({ data: { ...data, 'image/png': imageData } });
+            if (model.data['image/png'] !== imageData) {
+              model.setData({
+                data: { ...model.data, 'image/png': imageData }
+              });
+            }
           });
         });
       }
@@ -73,7 +77,9 @@ export class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
         height: this.node.offsetHeight
       }).then((url: string) => {
         const imageData = url.split(',')[1];
-        model.setData({ data: { ...data, 'image/png': imageData } });
+        if (model.data['image/png'] !== imageData) {
+          model.setData({ data: { ...model.data, 'image/png': imageData } });
+        }
       });
     });
   }


### PR DESCRIPTION
This PR is a fix for #158

It looks to me that after computing the png image, the `model.setData` call was treating
plotly's traces array (`data`) as if it were the bundle's `data` property (`model.data`).

This was causing a malformed bundle to be saved in the notebook, and causing only the image/png form to be restored on notebook load.

cc @gnestor 