### PR TITLE
@jupyterlab/katex-extension. Add settings section.

### DIFF
--- a/packages/katex-extension/package.json
+++ b/packages/katex-extension/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.19.1",
+    "@jupyterlab/coreutils": "^2.2.1",
     "@jupyterlab/rendermime": "^0.19.1",
     "@jupyterlab/rendermime-interfaces": "^1.1.2",
     "katex": "^0.9.0"

--- a/packages/katex-extension/package.json
+++ b/packages/katex-extension/package.json
@@ -17,6 +17,7 @@
   "files": [
     "lib/*.d.ts",
     "lib/*.js",
+    "schema/*.json",
     "style/*.*"
   ],
   "main": "lib/index.js",
@@ -46,6 +47,7 @@
     "typescript": "~3.1.1"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   }
 }

--- a/packages/katex-extension/schema/plugin.json
+++ b/packages/katex-extension/schema/plugin.json
@@ -1,0 +1,15 @@
+{
+  "title": "KaTeX",
+  "description": "KaTeX extension settings.",
+  "properties": {
+    "macros": {
+      "type": "object",
+      "title": "Macros",
+      "description":
+        "A collection of custom macros.\nEach macro is a property with a name like `\\name` (written `\\\\name`, escaping\nbackslash) which maps to a string that describes the expansion of the macro.\nSingle-character keys can also be included in which case the character will be\nredefined as the given macro (similar to TeX active characters).",
+      "default": {}
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/katex-extension/src/autorender.ts
+++ b/packages/katex-extension/src/autorender.ts
@@ -179,12 +179,17 @@ export interface IAutoRenderOptions extends katex.KatexOptions {
   readonly delimiters: IDelimiter[];
   readonly ignoredTags: string[];
   readonly throwOnError: boolean;
+  macros?: IMacros;
 }
 
 export interface IDelimiter {
   left: string;
   right: string;
   display: boolean;
+}
+
+export interface IMacros {
+  [s: string]: string;
 }
 
 const defaultAutoRenderOptions: IAutoRenderOptions = {
@@ -200,6 +205,10 @@ const defaultAutoRenderOptions: IAutoRenderOptions = {
   errorColor: '#CC0000',
   throwOnError: false
 };
+
+export function setMacros(macros: IMacros) {
+  defaultAutoRenderOptions.macros = macros;
+}
 
 export function renderMathInElement(
   elem: HTMLElement,

--- a/packages/katex-extension/src/autorender.ts
+++ b/packages/katex-extension/src/autorender.ts
@@ -206,17 +206,13 @@ const defaultAutoRenderOptions: IAutoRenderOptions = {
   throwOnError: false
 };
 
-export function setMacros(macros: IMacros) {
-  defaultAutoRenderOptions.macros = macros;
-}
-
 export function renderMathInElement(
   elem: HTMLElement,
-  options: IAutoRenderOptions = defaultAutoRenderOptions
+  options: Partial<IAutoRenderOptions> = {}
 ) {
   if (!elem) {
     throw new Error('No element provided to render');
   }
-  const optionsCopy = { ...options };
-  renderElem(elem, optionsCopy);
+  const fullOptions = { ...defaultAutoRenderOptions, ...options };
+  renderElem(elem, fullOptions);
 }

--- a/packages/katex-extension/src/index.ts
+++ b/packages/katex-extension/src/index.ts
@@ -7,13 +7,19 @@ import { ILatexTypesetter } from '@jupyterlab/rendermime';
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
-import { IMacros, renderMathInElement, setMacros } from './autorender';
+import { IMacros, renderMathInElement } from './autorender';
 
 import { ISettingRegistry } from '@jupyterlab/coreutils';
 
 import '../style/index.css';
 
 const katexPluginId = '@jupyterlab/katex-extension:plugin';
+
+interface IOptions {
+  macros?: IMacros;
+}
+
+const options: IOptions = {};
 
 /**
  * The KaTeX Typesetter.
@@ -23,7 +29,7 @@ export class KatexTypesetter implements IRenderMime.ILatexTypesetter {
    * Typeset the math in a node.
    */
   typeset(node: HTMLElement): void {
-    renderMathInElement(node);
+    renderMathInElement(node, options);
   }
 }
 
@@ -40,7 +46,7 @@ const katexPlugin: JupyterLabPlugin<ILatexTypesetter> = {
      */
     function updateSettings(settings: ISettingRegistry.ISettings): void {
       const macros = settings.get('macros').composite as IMacros;
-      setMacros(macros);
+      options.macros = macros;
     }
 
     settingRegistry

--- a/packages/katex-extension/src/index.ts
+++ b/packages/katex-extension/src/index.ts
@@ -1,15 +1,19 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterLabPlugin } from '@jupyterlab/application';
+import { JupyterLab, JupyterLabPlugin } from '@jupyterlab/application';
 
 import { ILatexTypesetter } from '@jupyterlab/rendermime';
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
-import { renderMathInElement } from './autorender';
+import { IMacros, renderMathInElement, setMacros } from './autorender';
+
+import { ISettingRegistry } from '@jupyterlab/coreutils';
 
 import '../style/index.css';
+
+const katexPluginId = '@jupyterlab/katex-extension:plugin';
 
 /**
  * The KaTeX Typesetter.
@@ -27,9 +31,29 @@ export class KatexTypesetter implements IRenderMime.ILatexTypesetter {
  * The KaTex extension.
  */
 const katexPlugin: JupyterLabPlugin<ILatexTypesetter> = {
-  id: 'jupyter.extensions.katex',
+  id: katexPluginId,
+  requires: [ISettingRegistry],
   provides: ILatexTypesetter,
-  activate: () => new KatexTypesetter(),
+  activate: (jupyterlab: JupyterLab, settingRegistry: ISettingRegistry) => {
+    /**
+     * Update the setting values.
+     */
+    function updateSettings(settings: ISettingRegistry.ISettings): void {
+      const macros = settings.get('macros').composite as IMacros;
+      setMacros(macros);
+    }
+
+    settingRegistry
+      .load(katexPluginId)
+      .then(settings => {
+        settings.changed.connect(updateSettings);
+        updateSettings(settings);
+      })
+      .catch((reason: Error) => {
+        console.error(reason.message);
+      });
+    return new KatexTypesetter();
+  },
   autoStart: true
 };
 


### PR DESCRIPTION
Add settings section to `katex-extension`.
For now, it contains just one entry, `macros`, a collection of custom  LaTeX macros.

Cheers 