### PR TITLE
plotly-extension: Accept config object in data

### DIFF
--- a/packages/plotly-extension/src/index.ts
+++ b/packages/plotly-extension/src/index.ts
@@ -47,11 +47,11 @@ export class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
    * Render Plotly into this widget's node.
    */
   renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-    const { data, layout, frames } = model.data[this._mimeType] as
+    const { data, layout, frames, config } = model.data[this._mimeType] as
       | any
       | IPlotlySpec;
     // const metadata = model.metadata[this._mimeType] as any || {};
-    return Plotly.newPlot(this.node, data, layout).then(plot => {
+    return Plotly.newPlot(this.node, data, layout, config).then(plot => {
       if (frames) {
         return Plotly.addFrames(this.node, frames).then(() => {
           Plotly.animate(this.node);


### PR DESCRIPTION
Related to https://github.com/plotly/plotly.py/pull/1281

This just accept a config object for plotly.js that can be passed by plotly.py or the user. 

Demo notebook: https://gist.github.com/gnestor/07f30edf28a8c3a88a01dfc748a8201a