### PR TITLE
Update publishing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jupyter lab --watch
 ### Publishing packages
 
 ```bash
-jlpm publish
+jlpm run publish
 # If publishing a package for the first time
 npm access public @jupyterlab/<extension name>
 ```


### PR DESCRIPTION
The command needs to be `jlpm run publish` vs. `jlpm publish`, otherwise yarn will get confused and throw a "Package marked as private, not publishing" error.