### PR TITLE
Update to MathJax 3.0 final

### DIFF
--- a/packages/mathjax3-extension/README.md
+++ b/packages/mathjax3-extension/README.md
@@ -1,13 +1,13 @@
 # MathJAX 3 extension
 
-A JupyterLab extension for rendering math with [MathJax 3 alpha](https://github.com/mathjax/mathjax-v3).
+A JupyterLab extension for rendering math with [MathJax 3](https://github.com/mathjax/mathjax).
 
-The default LaTeX renderer in JupyterLab uses [MathJax](https://www.mathjax.org/).
-This extension substitutes the MathJax renderer with the MathJax 3 (beta) renderer.
+The default LaTeX renderer in JupyterLab uses [MathJax 2](https://www.mathjax.org/).
+This extension substitutes the MathJax 2 renderer with the MathJax 3 renderer.
 
 ## Prerequisites
 
-* JupyterLab ^0.34
+* JupyterLab ^1.0
 * Node.js >= 8
 
 ## Install
@@ -27,7 +27,9 @@ npm install
 # Build Typescript source
 npm run build
 # Link your development version of the extension with JupyterLab
-jupyter labextension link packages/mathjax3-extension
+jupyter labextension install packages/mathjax3-extension
+# Disable the default mathjax 2 renderer
+jupyter labextension disable @jupyterlab/mathjax2-extension
 # Rebuild Typescript source after making changes
 npm run build
 # Rebuild JupyterLab after making any changes

--- a/packages/mathjax3-extension/package.json
+++ b/packages/mathjax3-extension/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "style": "style/index.css",
   "directories": {
     "lib": "lib/"
   },
@@ -37,7 +38,7 @@
   "dependencies": {
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/rendermime": "^1.0.0",
-    "mathjax3": "^3.0.0-beta.4"
+    "mathjax-full": "^3"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/packages/mathjax3-extension/package.json
+++ b/packages/mathjax3-extension/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/rendermime": "^1.0.0",
-    "mathjax-full": "^3"
+    "mathjax-full": "^3.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/packages/mathjax3-extension/scripts/generate-css.js
+++ b/packages/mathjax3-extension/scripts/generate-css.js
@@ -2,9 +2,9 @@
  * Prints the @font-face CSS directives for the CHTML TeX font
  */
 const fs = require('fs');
-const TeXFont = require('mathjax3/mathjax3/output/chtml/fonts/tex');
+const TeXFont = require('mathjax-full/js/output/chtml/fonts/tex');
 
-const CssStyles = require('mathjax3/mathjax3/output/common/CssStyles');
+const CssStyles = require('mathjax-full/js/output/common/CssStyles');
 
 class myFont extends TeXFont.TeXFont {}
 myFont.defaultVariants = [];
@@ -14,7 +14,7 @@ myFont.defaultVariantClasses = {};
 myFont.defaultStyles = {};
 
 const font = new myFont({
-  fontURL: '~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2' // Path to fonts.
+  fontURL: '~mathjax-full/es5/output/chtml/fonts/woff-v2' // Path to fonts.
 });
 
 const styles = new CssStyles.CssStyles();

--- a/packages/mathjax3-extension/src/index.ts
+++ b/packages/mathjax3-extension/src/index.ts
@@ -20,6 +20,8 @@ import { TeXFont } from 'mathjax-full/js/output/chtml/fonts/tex';
 
 import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html';
 
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages';
+
 RegisterHTMLHandler(browserAdaptor());
 
 // Override dynamically generated fonts in favor
@@ -32,8 +34,16 @@ class emptyFont extends TeXFont {}
  */
 export class MathJax3Typesetter implements ILatexTypesetter {
   constructor() {
-    const chtml = new CHTML({ font: new emptyFont() });
-    const tex = new TeX({ inlineMath: [['$', '$'], ['\\(', '\\)']] });
+    const chtml = new CHTML({
+      font: new emptyFont()
+    });
+    const tex = new TeX({
+      packages: AllPackages,
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']],
+      processEscapes: true,
+      processEnvironments: true
+    });
     this._html = mathjax.document(window.document, {
       InputJax: tex,
       OutputJax: chtml

--- a/packages/mathjax3-extension/src/index.ts
+++ b/packages/mathjax3-extension/src/index.ts
@@ -6,19 +6,19 @@ import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { ILatexTypesetter } from '@jupyterlab/rendermime';
 
 // MathJax core
-import { mathjax } from 'mathjax-full/ts/mathjax';
+import { mathjax } from 'mathjax-full/js/mathjax';
 
 // TeX input
-import { TeX } from 'mathjax-full/ts/input/tex';
+import { TeX } from 'mathjax-full/js/input/tex';
 
 // HTML output
-import { CHTML } from 'mathjax-full/ts/output/chtml';
+import { CHTML } from 'mathjax-full/js/output/chtml';
 
-import { browserAdaptor } from 'mathjax-full/ts/adaptors/browserAdaptor';
+import { browserAdaptor } from 'mathjax-full/js/adaptors/browserAdaptor';
 
-import { TeXFont } from 'mathjax-full/ts/output/chtml/fonts/tex';
+import { TeXFont } from 'mathjax-full/js/output/chtml/fonts/tex';
 
-import { RegisterHTMLHandler } from 'mathjax-full/ts/handlers/html';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html';
 
 RegisterHTMLHandler(browserAdaptor());
 

--- a/packages/mathjax3-extension/src/index.ts
+++ b/packages/mathjax3-extension/src/index.ts
@@ -6,24 +6,21 @@ import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { ILatexTypesetter } from '@jupyterlab/rendermime';
 
 // MathJax core
-import { MathJax } from 'mathjax3/mathjax3/mathjax';
+import { mathjax } from 'mathjax-full/ts/mathjax';
 
 // TeX input
-import { TeX } from 'mathjax3/mathjax3/input/tex';
+import { TeX } from 'mathjax-full/ts/input/tex';
 
 // HTML output
-import { CHTML } from 'mathjax3/mathjax3/output/chtml';
+import { CHTML } from 'mathjax-full/ts/output/chtml';
 
-import { browserAdaptor } from 'mathjax3/mathjax3/adaptors/browserAdaptor';
+import { browserAdaptor } from 'mathjax-full/ts/adaptors/browserAdaptor';
 
-import { TeXFont } from 'mathjax3/mathjax3/output/chtml/fonts/tex';
+import { TeXFont } from 'mathjax-full/ts/output/chtml/fonts/tex';
 
-import { RegisterHTMLHandler } from 'mathjax3/mathjax3/handlers/html';
+import { RegisterHTMLHandler } from 'mathjax-full/ts/handlers/html';
 
 RegisterHTMLHandler(browserAdaptor());
-
-// Load the MathJax fonts
-import '../style/index.css';
 
 // Override dynamically generated fonts in favor
 // of our font css that is picked up by webpack.
@@ -37,7 +34,7 @@ export class MathJax3Typesetter implements ILatexTypesetter {
   constructor() {
     const chtml = new CHTML({ font: new emptyFont() });
     const tex = new TeX({ inlineMath: [['$', '$'], ['\\(', '\\)']] });
-    this._html = MathJax.document(window.document, {
+    this._html = mathjax.document(window.document, {
       InputJax: tex,
       OutputJax: chtml
     });

--- a/packages/mathjax3-extension/style/fonts.css
+++ b/packages/mathjax3-extension/style/fonts.css
@@ -1,131 +1,109 @@
 @font-face /* 0 */ {
   font-family: MJXZERO;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Zero.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Zero.woff") format("woff");
 }
 
 @font-face /* 1 */ {
   font-family: MJXTEX;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Main-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Regular.woff") format("woff");
 }
 
 @font-face /* 2 */ {
   font-family: MJXTEX-B;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Main-Bold.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Bold.woff") format("woff");
 }
 
 @font-face /* 3 */ {
   font-family: MJXTEX-MI;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Main-Italic.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Main-Italic.woff") format("woff");
 }
 
 @font-face /* 4 */ {
   font-family: MJXTEX-I;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Math-Italic.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-Italic.woff") format("woff");
 }
 
 @font-face /* 5 */ {
   font-family: MJXTEX-BI;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Math-BoldItalic.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Math-BoldItalic.woff") format("woff");
 }
 
 @font-face /* 6 */ {
   font-family: MJXTEX-S1;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Size1-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size1-Regular.woff") format("woff");
 }
 
 @font-face /* 7 */ {
   font-family: MJXTEX-S2;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Size2-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size2-Regular.woff") format("woff");
 }
 
 @font-face /* 8 */ {
   font-family: MJXTEX-S3;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Size3-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size3-Regular.woff") format("woff");
 }
 
 @font-face /* 9 */ {
   font-family: MJXTEX-S4;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Size4-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Size4-Regular.woff") format("woff");
 }
 
 @font-face /* 10 */ {
   font-family: MJXTEX-A;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_AMS-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_AMS-Regular.woff") format("woff");
 }
 
 @font-face /* 11 */ {
   font-family: MJXTEX-C;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Caligraphic-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Regular.woff") format("woff");
 }
 
 @font-face /* 12 */ {
   font-family: MJXTEX-C-B;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Caligraphic-Bold.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Calligraphic-Bold.woff") format("woff");
 }
 
 @font-face /* 13 */ {
   font-family: MJXTEX-FR;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Fraktur-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Regular.woff") format("woff");
 }
 
 @font-face /* 14 */ {
   font-family: MJXTEX-FR-B;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Fraktur-Bold.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Fraktur-Bold.woff") format("woff");
 }
 
 @font-face /* 15 */ {
   font-family: MJXTEX-SS;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_SansSerif-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Regular.woff") format("woff");
 }
 
 @font-face /* 16 */ {
   font-family: MJXTEX-SS-B;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_SansSerif-Bold.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Bold.woff") format("woff");
 }
 
 @font-face /* 17 */ {
   font-family: MJXTEX-SS-I;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_SansSerif-Italic.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_SansSerif-Italic.woff") format("woff");
 }
 
 @font-face /* 18 */ {
   font-family: MJXTEX-SC;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Script-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Script-Regular.woff") format("woff");
 }
 
 @font-face /* 19 */ {
   font-family: MJXTEX-T;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Typewriter-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Typewriter-Regular.woff") format("woff");
 }
 
 @font-face /* 20 */ {
   font-family: MJXTEX-V;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Vector-Regular.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Regular.woff") format("woff");
 }
 
 @font-face /* 21 */ {
   font-family: MJXTEX-VB;
-  src: url('~mathjax3/mathjax3-ts/output/chtml/fonts/tex-woff-v2/MathJax_Vector-Bold.woff')
-    format('woff');
+  src: url("~mathjax-full/es5/output/chtml/fonts/woff-v2/MathJax_Vector-Bold.woff") format("woff");
 }

--- a/packages/mathjax3-extension/tsconfig.json
+++ b/packages/mathjax3-extension/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUnusedLocals": false
   },
   "include": ["src/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,7 +5673,7 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
-mathjax-full@^3:
+mathjax-full@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mathjax-full/-/mathjax-full-3.0.0.tgz#a16c5bf4ae5ae6797fccfbd6dd11cc59052570f1"
   integrity sha512-DvTUi2WvrACXZRjjzS0EbXY2ssRD23yuSMHVYZNbRuCA5zFZvu0MZWFy8QRvNYwJ44hJirJCNOCii0W0Q1R62A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,6 +3161,11 @@ eslint-plugin-prettier@^2.2.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 esprima@^1.0.3:
   version "1.2.5"
   resolved "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz#0993502feaf668138325756f30f9a51feeec11e9"
@@ -5668,13 +5673,14 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
-mathjax3@^3.0.0-beta.4:
-  version "3.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/mathjax3/-/mathjax3-3.0.0-beta.4.tgz#e10ad04454e6a511b20c8e092439638dc3a62ea5"
-  integrity sha512-WN6qvlv544TZ+yJVfRKJc68uAa59E55LdJa1mnPb8kLKSwupD+FWgppgnrGilbebnchFFl/zvEkPDf79eO/1Ag==
+mathjax-full@^3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mathjax-full/-/mathjax-full-3.0.0.tgz#a16c5bf4ae5ae6797fccfbd6dd11cc59052570f1"
+  integrity sha512-DvTUi2WvrACXZRjjzS0EbXY2ssRD23yuSMHVYZNbRuCA5zFZvu0MZWFy8QRvNYwJ44hJirJCNOCii0W0Q1R62A==
   dependencies:
+    esm "^3.2.25"
     mj-context-menu "^0.2.0"
-    speech-rule-engine "^2.4.0"
+    speech-rule-engine "^3.0.0-beta.6"
 
 matrix-camera-controller@^2.1.1, matrix-camera-controller@^2.1.3:
   version "2.1.3"
@@ -8097,14 +8103,14 @@ spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
-speech-rule-engine@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/speech-rule-engine/-/speech-rule-engine-2.4.0.tgz#c51cadd81c456623aff09790bf9c0e5d2fee15f9"
-  integrity sha512-7IXDmpGiQOJWUPVy/rcayqi1aTCrhcQ/bVACu2oyueEuiYzPW8GebYRF4LeyMROL/E0kxkO5U66t0aFWCv0QCQ==
+speech-rule-engine@^3.0.0-beta.6:
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/speech-rule-engine/-/speech-rule-engine-3.0.0-beta.6.tgz#77b0ed9570eccd0a5f71d387ae0da8221d720fd0"
+  integrity sha512-B7gcT53jAsKpx7WvFYQcyUlFmgS3Wa9KlDy0FY8SOTa+Wz5EqmI0MpCD5/fYm8/2qiCPp8HwZg+H3cBgM+sNVw==
   dependencies:
     commander "*"
     wicked-good-xpath "*"
-    xmldom-sre ">=0.1.31"
+    xmldom-sre "^0.1.31"
 
 split-polygon@^1.0.0:
   version "1.0.0"
@@ -9967,7 +9973,7 @@ xmldoc@^0.5.1:
   dependencies:
     sax "~1.1.1"
 
-xmldom-sre@>=0.1.31:
+xmldom-sre@^0.1.31:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom-sre/-/xmldom-sre-0.1.31.tgz#10860d5bab2c603144597d04bf2c4980e98067f4"
   integrity sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==


### PR DESCRIPTION
We compile without noUnusedLocals because MathJax has lots of errors with it on. See https://github.com/mathjax/MathJax-src/issues/347 for an issue about that.