### PR TITLE
geojson: support JupyterLab 2.1.0

### DIFF
--- a/packages/geojson-extension/package.json
+++ b/packages/geojson-extension/package.json
@@ -34,7 +34,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/apputils": "~2.0.0",
+    "@jupyterlab/apputils": "^2.0.0",
     "@jupyterlab/rendermime-interfaces": "^2.0.0",
     "@lumino/messaging": "^1.2.2",
     "@lumino/widgets": "^1.11.0",


### PR DESCRIPTION
Among the packages in this repo, only the geojson extension had apputils pinned with `~`, so I assume it is set too restrictive by mistake.

```
>=2.1.0 <2.2.0       >=2.0.0 <2.1.0 @jupyterlab/apputils
JupyterLab           Extension      Package
Conflicting Dependencies:
ValueError: The extension "@jupyterlab/geojson-extension" does not yet support the current version of JupyterLab.
```