### PR TITLE
Simplify mathjax calls to call the built-in rendering pipeline.

### DIFF
--- a/packages/mathjax3-extension/src/index.ts
+++ b/packages/mathjax3-extension/src/index.ts
@@ -47,9 +47,9 @@ export class MathJax3Typesetter implements ILatexTypesetter {
       processEscapes: true,
       processEnvironments: true
     });
-    this._html = mathjax.document(window.document, {
+    this._mathDocument = mathjax.document(window.document, {
       InputJax: tex,
-      OutputJax: chtml
+      OutputJax: chtml,
     });
   }
 
@@ -57,15 +57,12 @@ export class MathJax3Typesetter implements ILatexTypesetter {
    * Typeset the math in a node.
    */
   typeset(node: HTMLElement): void {
-    this._html
-      .clear()
-      .findMath({ elements: [node] })
-      .compile()
-      .getMetrics()
-      .typeset()
-      .updateDocument();
+    this._mathDocument.options.elements = [node];
+    this._mathDocument.clear().render();
+    delete this._mathDocument.options.elements;
   }
-  private _html: any;
+
+  private _mathDocument: ReturnType<typeof mathjax.document>;
 }
 
 /**


### PR DESCRIPTION
Building on comments from @dpvc (thanks!) at https://github.com/jupyterlab/jupyter-renderers/pull/236#issuecomment-776808718, this simplifies our rendering to call the built-in rendering pipeline.