### PR TITLE
Update the auto-skipping in setup.py to look for PKG-INFO

### DIFF
--- a/packages/fasta-extension/setup.py
+++ b/packages/fasta-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 

--- a/packages/geojson-extension/setup.py
+++ b/packages/geojson-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 

--- a/packages/katex-extension/setup.py
+++ b/packages/katex-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 

--- a/packages/mathjax3-extension/setup.py
+++ b/packages/mathjax3-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 

--- a/packages/vega2-extension/setup.py
+++ b/packages/vega2-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 

--- a/packages/vega3-extension/setup.py
+++ b/packages/vega3-extension/setup.py
@@ -46,11 +46,11 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = (HERE / ".git").exists()
-if is_repo:
-    cmdclass["jsdeps"] = js_command
-else:
+if (HERE / "PKG-INFO").exists():
+    # In an extracted python source package
     cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+else:
+    cmdclass["jsdeps"] = js_command
 
 long_description = (HERE / "README.md").read_text()
 


### PR DESCRIPTION
Being a monorepo, `.git` is not in each package directory. Instead, we look for the PKG-INFO file that will be in a .tar.gz package, and reverse the logic of the check.