### PR TITLE
fix: swap to @jlab-contrib/msa

### DIFF
--- a/packages/fasta-extension/package.json
+++ b/packages/fasta-extension/package.json
@@ -55,7 +55,7 @@
     "@jupyterlab/rendermime-interfaces": "^3.0.5",
     "@lumino/messaging": "^1.4.3",
     "@lumino/widgets": "^1.16.1",
-    "msa": "^1.0.3"
+    "@jlab-contrib/msa": "^1.1.2"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0",

--- a/packages/fasta-extension/src/index.ts
+++ b/packages/fasta-extension/src/index.ts
@@ -9,7 +9,7 @@ import { Message } from '@lumino/messaging';
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
-import * as msa from 'msa';
+import * as msa from '@jlab-contrib/msa';
 
 import '../style/msa.css';
 

--- a/packages/fasta-extension/src/msa.d.ts
+++ b/packages/fasta-extension/src/msa.d.ts
@@ -3,4 +3,4 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-declare module 'msa';
+declare module '@jlab-contrib/msa';

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,32 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
+"@jlab-contrib/msa@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jlab-contrib/msa/-/msa-1.1.2.tgz#ec754bd5d40ab4be3ab036a7bbc0b777e23cd045"
+  integrity sha512-T0+PbCYEQTDIwZXo0G1lMgycDLinG9GOte2eXA2Q8Yf8m7TmkqBY9UBdBen9f8gAfAijE5Jqm5TS9HxMnQmhrA==
+  dependencies:
+    backbone-childs "^1.0.3"
+    backbone-thin "^1.0.8"
+    backbone-viewj "^1.0.1"
+    bio.io "^1.0.6"
+    biojs-events "^0.0.4"
+    biojs-model "^0.0.5"
+    biojs-vis-seqlogo "0.0.14"
+    blueimp_canvastoblob "^1.0.0"
+    browser-saveas "^1.0.1"
+    canvas2svg "^1.0.16"
+    dom-helper "^1.0.0"
+    html2canvas "^1.0.0-rc.7"
+    jbone "^1.1.2"
+    koala-js "^1.0.7"
+    linear-scale "^0.0.3"
+    lodash "^4.13.1"
+    mouse-pos "^1.0.3"
+    msa-colorschemes "^1.0.10"
+    msa-seqtools "^0.1.8"
+    xhr "^2.2.0"
+
 "@jupyterlab/application@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@jupyterlab/application/-/application-3.0.6.tgz#9729bd42b24f0191859a34711d7e2f8353d371d1"
@@ -2067,6 +2093,16 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-arraybuffer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz#4b944fac0191aa5907afe2d8c999ccc57ce80f45"
+  integrity sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==
+
+base64-arraybuffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz#87bd13525626db4a9838e00a508c2b73efcf348c"
+  integrity sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2112,17 +2148,17 @@ bio.io@^1.0.6:
     xhr "^2.2.0"
     xmldoc "^0.5.1"
 
-biojs-events@0.0.4, biojs-events@^0.0.4:
+biojs-events@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/biojs-events/-/biojs-events-0.0.4.tgz#ee4a3deb5e2ab3d7f0857686630129cb217ec7e8"
   integrity sha1-7ko9614qs9fwhXaGYwEpyyF+x+g=
   dependencies:
     backbone-events-standalone "^0.2.2"
 
-biojs-model@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/biojs-model/-/biojs-model-0.0.2.tgz#cb8890f2dbc9cd9a7f099f3f49e36a860b341261"
-  integrity sha1-y4iQ8tvJzZp/CZ8/SeNqhgs0EmE=
+biojs-model@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/biojs-model/-/biojs-model-0.0.5.tgz#fb366fbd13c38b76ac7d5c7aaa3b14efbbd5141a"
+  integrity sha1-+zZvvRPDi3asfVx6qjsU77vVFBo=
 
 biojs-vis-seqlogo@0.0.14:
   version "0.0.14"
@@ -2403,6 +2439,11 @@ caniuse-lite@^1.0.30001219:
   version "1.0.30001230"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
   integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+
+canvas2svg@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/canvas2svg/-/canvas2svg-1.0.16.tgz#0814c53bbab7c3406e7387279cdf257fe4f6f2bd"
+  integrity sha1-CBTFO7q3w0Buc4cnnN8lf+T28r0=
 
 canvas@^1.2.9, canvas@^1.3.4:
   version "1.6.13"
@@ -2884,6 +2925,13 @@ crypto@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
   integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
+css-line-break@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.0.1.tgz#3dc74c2ed5eb64211480281932475790243e7338"
+  integrity sha512-gwKYIMUn7xodIcb346wgUhE2Dt5O1Kmrc16PWi8sL4FTfyDj8P5095rzH7+O8CTZudJr+uw2GCI/hwEkDJFI2w==
+  dependencies:
+    base64-arraybuffer "^0.2.0"
 
 css-loader@^5.0.1:
   version "5.1.1"
@@ -4498,6 +4546,14 @@ hosted-git-info@^3.0.6:
   dependencies:
     lru-cache "^6.0.0"
 
+html2canvas@^1.0.0-rc.7:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.0.tgz#e9db68a47486f2e884fea46b28a3a10f6c17b66f"
+  integrity sha512-vQMssxs2HvLuy7T0JrQqirRQxnhfB7KaHRSsQVV2WaNlXMqqhwv0gH+JUkkaWCednbDWZtRF7Msb/pbTkbcrpA==
+  dependencies:
+    css-line-break "2.0.1"
+    text-segmentation "^1.0.2"
+
 htmlparser2@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
@@ -5376,10 +5432,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-linear-scale@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/linear-scale/-/linear-scale-0.0.1.tgz#6a1445f647e0cbeb01d970dc2724608b2254f119"
-  integrity sha1-ahRF9kfgy+sB2XDcJyRgiyJU8Rk=
+linear-scale@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/linear-scale/-/linear-scale-0.0.3.tgz#09977293326e2d41e4e053558805fdb806011273"
+  integrity sha512-arroGV9oc2GCnCQr/aO1bPIY2Al9hUmlnD04K/KYFOXXerGKaSL/trEy9+rlg1xyZl/kqWSIeg919+sUSJy0mQ==
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -5779,14 +5835,6 @@ memorystream@^0.3.1:
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
-menu-builder@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/menu-builder/-/menu-builder-0.0.7.tgz#7455595c416cd006412e1ffb76e01e08a23c8ae3"
-  integrity sha1-dFVZXEFs0AZBLh/7duAeCKI8iuM=
-  dependencies:
-    backbone-viewj "^1.0.1"
-    jbone "^1.0.19"
-
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -6097,30 +6145,10 @@ msa-colorschemes@^1.0.10:
   resolved "https://registry.yarnpkg.com/msa-colorschemes/-/msa-colorschemes-1.0.10.tgz#da2a7e4833b9480f39c2369deb9bb4a954e4c115"
   integrity sha1-2ip+SDO5SA85wjad65u0qVTkwRU=
 
-msa@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/msa/-/msa-1.0.3.tgz#8ddb3cae5edb17d50d9137880a75bb04a665eb8d"
-  integrity sha1-jds8rl7bF9UNkTeICnW7BKZl640=
-  dependencies:
-    backbone-childs "^1.0.3"
-    backbone-thin "^1.0.8"
-    backbone-viewj "^1.0.1"
-    bio.io "^1.0.6"
-    biojs-events "^0.0.4"
-    biojs-model "^0.0.2"
-    biojs-vis-seqlogo "0.0.14"
-    blueimp_canvastoblob "^1.0.0"
-    browser-saveas "^1.0.1"
-    dom-helper "^1.0.0"
-    jbone "^1.1.2"
-    koala-js "^1.0.7"
-    linear-scale "0.0.1"
-    lodash "^4.13.1"
-    menu-builder "^0.0.7"
-    mouse-pos "^1.0.3"
-    msa-colorschemes "^1.0.10"
-    stat.seqs "^0.1.21"
-    xhr "^2.2.0"
+msa-seqtools@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/msa-seqtools/-/msa-seqtools-0.1.8.tgz#21111848d69d89190a60a35fa991b604e60a3afa"
+  integrity sha1-IREYSNadiRkKYKNfqZG2BOYKOvo=
 
 multimatch@^3.0.0:
   version "3.0.0"
@@ -8039,14 +8067,6 @@ staged-git-files@1.1.1:
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
   integrity sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==
 
-stat.seqs@^0.1.21:
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/stat.seqs/-/stat.seqs-0.1.21.tgz#51af4b09a3f3c3c5c6d8e4dd1d90bc6369d6a5ed"
-  integrity sha1-Ua9LCaPzw8XG2OTdHZC8Y2nWpe0=
-  dependencies:
-    biojs-events "0.0.4"
-    underscore "^1.7.0"
-
 static-eval@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.1.0.tgz#a16dbe54522d7fa5ef1389129d813fd47b148014"
@@ -8431,6 +8451,13 @@ text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
+
+text-segmentation@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.2.tgz#1f828fa14aa101c114ded1bda35ba7dcc17c9858"
+  integrity sha512-uTqvLxdBrVnx/CFQOtnf8tfzSXFm+1Qxau7Xi54j4OPTZokuDOX8qncQzrg2G8ZicAMOM8TgzFAYTb+AqNO4Cw==
+  dependencies:
+    utrie "^1.0.1"
 
 then-request@^2.0.1:
   version "2.2.0"
@@ -8883,6 +8910,13 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
+
+utrie@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.1.tgz#e155235ebcbddc89ae09261ab6e773ce61401b2f"
+  integrity sha512-JPaDXF3vzgZxfeEwutdGzlrNoVFL5UvZcbO6Qo9D4GoahrieUPoMU8GCpVpR7MQqcKhmShIh8VlbEN3PLM3EBg==
+  dependencies:
+    base64-arraybuffer "^1.0.1"
 
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
Swap from the unmaintained [wilzbach/msa](https://github.com/wilzbach/msa) to a fork ([jupyterlab-contrib/msa](https://github.com/jupyterlab-contrib/msa)) with bugfixes.

This fixes issues with the MSA visualiser not displaying in new browsers.
![running on my laptop](https://user-images.githubusercontent.com/10497077/149068806-b0dbcf76-25c7-4a53-9bee-e5eb25bbb7ec.png)


I've also reverted the `bio.io` dependency for `msa` to `v1.0.6` (https://github.com/jupyterlab-contrib/msa/commit/1d353efa5b59a94dc1edb14c97ecdfe9abfc99d8), which misses the latest `clustal` patches (https://github.com/wilzbach/bio.io/commit/233c569a000b4e481bc682dc1c5024aaa8f4c3b6).  
These were not included in the latest NPM build for `msa`, but might be worth later incorporating.
For this we'll need to fork `bio.io` too.

Hopefully everything is up to scratch!

Closes #258.