### PR TITLE
Remove dependency to JupyterLab

### DIFF
--- a/packages/fasta-extension/setup.py
+++ b/packages/fasta-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/packages/geojson-extension/setup.py
+++ b/packages/geojson-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/packages/katex-extension/setup.py
+++ b/packages/katex-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/packages/mathjax3-extension/setup.py
+++ b/packages/mathjax3-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/packages/vega2-extension/setup.py
+++ b/packages/vega2-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/packages/vega3-extension/setup.py
+++ b/packages/vega3-extension/setup.py
@@ -69,9 +69,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab~=3.0",
-    ],
+    install_requires=[],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
Other software may use these pkgs without the need for JupyterLab to be installed